### PR TITLE
Added sideways buffer printing for long text bands

### DIFF
--- a/src/Thermal_Printer.cpp
+++ b/src/Thermal_Printer.cpp
@@ -1606,6 +1606,31 @@ int i;
   tpPostGraphics();
 
 } /* tpPrintBuffer() */
+
+void tpPrintBufferSide(void)
+{
+uint8_t *s;
+int x, y;
+uint8_t line[bb_pitch] = {0};
+
+  if (!bConnected)
+    return;
+
+  tpPreGraphics(bb_height, bb_width);
+  // Print the graphics
+  s = pBackBuffer;
+  for (y=0; y<bb_width; y++) {
+    for (x=0; x<bb_height; x++)
+    {
+      line[x/8] = (line[x/8] << 1) | (((*(s+((x+1)*bb_width-1-y)/8)) >> (y%8))&1);
+    }
+    tpSendScanline(line, bb_pitch);
+  } // for y
+  
+  tpPostGraphics();
+
+} /* tpPrintBufferSide() */
+
 //
 // Draw a line between 2 points
 //

--- a/src/Thermal_Printer.h
+++ b/src/Thermal_Printer.h
@@ -190,6 +190,10 @@ int tpSetPixel(int x, int y, uint8_t ucColor);
 //
 void tpPrintBuffer(void);
 //
+// Same as tpPrintBuffer, but output will be rotated by 90 degrees
+//
+void tpPrintBufferSide(void);
+//
 // Draw a line between 2 points
 //
 void tpDrawLine(int x1, int y1, int x2, int y2, uint8_t ucColor);


### PR DESCRIPTION
Added sideways buffer printing for long texts but don't know how to document it in the wiki.

PS: I'm using a cat printer (the smaller C15 one) with an ESP32 and it works when using `#define NIMBLE_SUPPORT`.