### PR TITLE
Add MX06 printer definition

### DIFF
--- a/src/Thermal_Printer.cpp
+++ b/src/Thermal_Printer.cpp
@@ -81,6 +81,7 @@ const PRINTERID szPrinterIDs[] = {
 	{(char *)"PeriPage+", PRINTER_PERIPAGEPLUS},
 	{(char *)"PeriPage_", PRINTER_PERIPAGE},
 	{(char *)"T02", PRINTER_FOMEMO},
+	{(char *)"MX06", PRINTER_CAT},
 	{NULL, 0}		// terminator
 };
 const int iPrinterWidth[] = {384, 576, 384, 576, 384, 384};


### PR DESCRIPTION
Added printer definition for MX06 printer - I have tested with the multiple example scripts (using an Adafruit ESP32 Feather) and they work with no additional changes.