### PR TITLE
[FIX] pRemoteCharacteristicNotify Null-Check Logic

### DIFF
--- a/src/Thermal_Printer.cpp
+++ b/src/Thermal_Printer.cpp
@@ -847,7 +847,7 @@ int tpConnect(const char *szMacAddress)
 #ifdef DEBUG_OUTPUT
           Serial.println("Got data transfer characteristic!");
 #endif
-          if (pRemoteCharacteristicData != NULL)
+          if (pRemoteCharacteristicNotify != NULL)
             if(pRemoteCharacteristicNotify->canNotify())
               pRemoteCharacteristicNotify->registerForNotify(ESP_notify_callback);
 


### PR DESCRIPTION
## Summary
Fixed Null-Check Logic for pRemoteCharacteristicNotify

## Description
- When use PT-210 Printer, `pRemoteCharacteristicNotify` Value is `NULL`.
- But at Line 850, it checks about if `pRemoteCharacteristicData` is `NULL` that is already done at Line 845.
- So it does not check about if `pRemoteCharacteristicNotify` is `NULL` so when we use PT-210 Printer, Library makes `abort()` Issue at Line 850.
- So I changed the Null-Check Logic for `pRemoteCharacteristicNotify`.