### PR TITLE
Add MP583 to the list of supported printers

### DIFF
--- a/src/Thermal_Printer.cpp
+++ b/src/Thermal_Printer.cpp
@@ -67,6 +67,7 @@ struct PRINTERID
 // Names and types of supported printers
 const PRINTERID szPrinterIDs[] PROGMEM = {
         {(char *)"MP210", PRINTER_MTP2},
+	{(char *)"MP583", PRINTER_MTP2},
 	{(char *)"PT-210", PRINTER_MTP2},
 	{(char *)"MTP-2", PRINTER_MTP2},
 	{(char *)"MPT-II", PRINTER_MTP2},


### PR DESCRIPTION
I was able to use my MP583 printer directly with the library. For direct use, the name just needs to be added to the list of supported devices.