### PR TITLE
Fix Bluetooth address error

### DIFF
--- a/src/Thermal_Printer.cpp
+++ b/src/Thermal_Printer.cpp
@@ -800,7 +800,7 @@ int tpConnect(const char *szMacAddress)
        if (Server_BLE_Address != NULL) {
           delete Server_BLE_Address;
        }
-       Server_BLE_Address = new BLEAddress(String(szMacAddress));
+       Server_BLE_Address = new BLEAddress(std::string(szMacAddress));
 #ifdef DEBUG_OUTPUT
        Serial.printf(" - Created client, connecting to %s\n", szMacAddress);
 #endif


### PR DESCRIPTION
This pull request fixes the BLEAddress initialization issue in `tpConnect`. The constructor of `BLEAddress` requires a `std::string` or `uint8_t*`, but the code was passing an Arduino `String`. This caused compilation errors. The fix converts the `String` to a `std::string` using `c_str()`.

```
.pio/libdeps/testing/Thermal Printer Library/src/Thermal_Printer.cpp: In function 'int tpConnect(const char*)':
.pio/libdeps/testing/Thermal Printer Library/src/Thermal_Printer.cpp:803:64: error: no matching function for call to 'BLEAddress::BLEAddress(String)'
        Server_BLE_Address = new BLEAddress(String(szMacAddress));
                                                                ^
In file included from .platformio/packages/framework-arduinoespressif32/libraries/BLE/src/BLEServer.h:24,
                 from .platformio/packages/framework-arduinoespressif32/libraries/BLE/src/BLEDevice.h:18,
                 from .pio/libdeps/testing/Thermal Printer Library/src/Thermal_Printer.cpp:31:
.platformio/packages/framework-arduinoespressif32/libraries/BLE/src/BLEAddress.h:24:2: note: candidate: 'BLEAddress::BLEAddress(std::__cxx11::string)'
  BLEAddress(std::string stringAddress);
  ^~~~~~~~~~
.platformio/packages/framework-arduinoespressif32/libraries/BLE/src/BLEAddress.h:24:2: note:   no known conversion for argument 1 from 'String' to 'std::__cxx11::string' {aka 'std::__cxx11::basic_string<char>'}
.platformio/packages/framework-arduinoespressif32/libraries/BLE/src/BLEAddress.h:23:2: note: candidate: 'BLEAddress::BLEAddress(uint8_t*)'
  BLEAddress(esp_bd_addr_t address);
  ^~~~~~~~~~
.platformio/packages/framework-arduinoespressif32/libraries/BLE/src/BLEAddress.h:23:2: note:   no known conversion for argument 1 from 'String' to 'uint8_t*' {aka 'unsigned char*'}
.platformio/packages/framework-arduinoespressif32/libraries/BLE/src/BLEAddress.h:21:7: note: candidate: 'constexpr BLEAddress::BLEAddress(const BLEAddress&)'
 class BLEAddress {
       ^~~~~~~~~~
.platformio/packages/framework-arduinoespressif32/libraries/BLE/src/BLEAddress.h:21:7: note:   no known conversion for argument 1 from 'String' to 'const BLEAddress&'
.platformio/packages/framework-arduinoespressif32/libraries/BLE/src/BLEAddress.h:21:7: note: candidate: 'constexpr BLEAddress::BLEAddress(BLEAddress&&)'
.platformio/packages/framework-arduinoespressif32/libraries/BLE/src/BLEAddress.h:21:7: note:   no known conversion for argument 1 from 'String' to 'BLEAddress&&'
Compiling .pio\build\testing\libc94\WiFiClientSecure\WiFiClientSecure.cpp.o
*** [.pio\build\testing\lib2c4\Thermal Printer Library\Thermal_Printer.cpp.o] Error 1
```

## Steps to reproduce the issue:
- Compile the code with the current implementation on PlatformIO

## Steps to verify the fix:
- Compile the code after applying this fix and ensure no errors.
- Test the BLE functionality to confirm expected behavior.

Please review and merge. Thank you!


My `platformio.ini` in case you want to replicate it:

```ini
[platformio]
default_envs = testing

; Common settings for all environments
[env]
platform = espressif32
board = dfrobot_firebeetle32s3_n16r8
framework = arduino
board_build.arduino.memory_type = qio_opi
board_build.prsam_type = opi
monitor_speed = 115200
monitor_dtr = 0
monitor_rts = 0
upload_speed = 921600
lib_ldf_mode = deep
lib_deps = 
       ;... several libs, plus others of bitbank2
	https://github.com/bitbank2/PNGdec.git
	https://github.com/bitbank2/JPEGDEC.git
	https://github.com/bitbank2/Thermal_Printer.git
build_flags = 
	-DBOARD_HAS_PSRAM
	-DCONFIG_ESP32_SPIRAM_SUPPORT
	-DMAX_FACES=1
	-mfix-esp32-psram-cache-issue

; Release build environment
[env:release]
extends = env
build_type = release
build_flags = 
	${env.build_flags}
	-DCORE_DEBUG_LEVEL=0
monitor_filters = colorize, debug, esp32_exception_decoder, time

[env:testing]
extends = env
build_type = debug
build_flags = 
	${env.build_flags}
	-DCORE_DEBUG_LEVEL=5
monitor_filters = time, esp32_exception_decoder, colorize, log2file
;, log2file
````