### PR TITLE
Bugfix #63, MX10 cat printer uses 16-bit commands for feed

### DIFF
--- a/src/Thermal_Printer.cpp
+++ b/src/Thermal_Printer.cpp
@@ -1496,12 +1496,22 @@ void tpFeed(int iLines)
 {
 uint8_t ucTemp[16];
 
-  if (bConnected && iLines < 0 && iLines > -256 && ucPrinterType == PRINTER_CAT)
-     tpWriteCatCommandD8(paperRetract,abs(iLines));			// some cat printers support retrack. Not all :(
+  if (bConnected && iLines < 0 && iLines > -256 && ucPrinterType == PRINTER_CAT) {
+    // some cat printers support retrack. Not all :(
+    if (strcmp(szPrinterName, "MX10") == 0) {
+      tpWriteCatCommandD16(paperRetract,abs(iLines));
+    } else {
+      tpWriteCatCommandD8(paperRetract,abs(iLines));
+    }
+  }
   if (!bConnected || iLines < 0 || iLines > 255)
     return;
   if (ucPrinterType == PRINTER_CAT) {
-     tpWriteCatCommandD8(paperFeed,iLines);
+    if (strcmp(szPrinterName, "MX10") == 0) {
+      tpWriteCatCommandD16(paperFeed,iLines);
+    } else {
+      tpWriteCatCommandD8(paperFeed,iLines);
+    }
   } else if (ucPrinterType == PRINTER_FOMEMO || ucPrinterType == PRINTER_MTP2 || ucPrinterType == PRINTER_MTP3) {
    // The PT-210 doesn't have a "feed-by-line" command
    // so instead, we'll send 1 byte-wide graphics of a blank segment


### PR DESCRIPTION
The MX10 cat printer needs to use tpWriteCatCommandD16 instead of tpWriteCatCommandD8 for paper feed and retraction, as mentioned in #63. I only have access to an MX10 so don't know if other cat printers also need the fix, but I can at least confirm it now works with my printer.