### PR TITLE
added new vendor name for SC03H-D4CD issue #72

### DIFF
--- a/src/Thermal_Printer.cpp
+++ b/src/Thermal_Printer.cpp
@@ -84,6 +84,7 @@ const PRINTERID szPrinterIDs[] PROGMEM = {
 	{(char *)"T02", PRINTER_FOMEMO},
 	{(char *)"MX06", PRINTER_CAT},
 	{(char *)"MX10", PRINTER_CAT},
+  {(char *)"SC03h-D4C", PRINTER_CAT},
 	{NULL, 0}		// terminator
 };
 const int iPrinterWidth[] = {384, 576, 384, 576, 384, 384};

--- a/src/Thermal_Printer.cpp
+++ b/src/Thermal_Printer.cpp
@@ -84,7 +84,7 @@ const PRINTERID szPrinterIDs[] PROGMEM = {
 	{(char *)"T02", PRINTER_FOMEMO},
 	{(char *)"MX06", PRINTER_CAT},
 	{(char *)"MX10", PRINTER_CAT},
-  {(char *)"SC03h-D4C", PRINTER_CAT},
+	{(char *)"SC03h-D4C", PRINTER_CAT},
 	{NULL, 0}		// terminator
 };
 const int iPrinterWidth[] = {384, 576, 384, 576, 384, 384};

--- a/src/Thermal_Printer.cpp
+++ b/src/Thermal_Printer.cpp
@@ -64,7 +64,11 @@ struct PRINTERID
   const char *szBLEName;
   uint8_t ucBLEType;
 } ;
+
 // Names and types of supported printers
+//
+// NOTE: For new controllers, add a new entry to the end of this list
+// and chop off the device name to 9 characters or less.
 const PRINTERID szPrinterIDs[] PROGMEM = {
         {(char *)"MP210", PRINTER_MTP2},
 	{(char *)"MP583", PRINTER_MTP2},


### PR DESCRIPTION
## Summary

This pull request resolve the issue #72 

## Details

My initial error trying to give support to this printer, was that I don't seen the comment on the code regarding to the instruction that the device name should be chop off to 9. Maybe we should add a section on the README file around the contributions of new printers in the future explaining that.

## Output:

![photo_2025-05-29_01-11-35](https://github.com/user-attachments/assets/ab46987d-a92e-4e82-a576-a5730ee8c700)

